### PR TITLE
KoboCloud Rclone update

### DIFF
--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -46,16 +46,19 @@ then
       echo "NickelDBus not found: installing it!"
       wget "https://github.com/shermp/NickelDBus/releases/download/0.2.0/KoboRoot.tgz" -O - | tar xz -C /
   fi
-  if [ -f "${RCLONE}" ]
+  RCLONEVERSION=1.66.0
+  RCLONESIZE=56885400
+  if [[ -f "${RCLONE}"  &&  $(stat -c %s "${RCLONE}") = "${RCLONESIZE}" ]]
   then
       echo "rclone found"
   else
-      echo "rclone not found: installing it!"
+      echo "rclone not found: installing rclone version ${RCLONEVERSION} (size ${RCLONESIZE})!"
       mkdir -p "${RCLONEDIR}"
       rcloneTemp="${RCLONEDIR}/rclone.tmp.zip"
       rm -f "${rcloneTemp}"
-      wget "https://github.com/rclone/rclone/releases/download/v1.64.0/rclone-v1.64.0-linux-arm-v7.zip" -O "${rcloneTemp}"
-      unzip -p "${rcloneTemp}" rclone-v1.64.0-linux-arm-v7/rclone > ${RCLONE}
+      # get rclone distribution with wget, unzip it, but remove it if it failed
+      wget "https://github.com/rclone/rclone/releases/download/v${RCLONEVERSION}/rclone-v${RCLONEVERSION}-linux-arm-v7.zip" -O "${rcloneTemp}" &&
+      unzip -p "${rcloneTemp}" rclone-v${RCLONEVERSION}-linux-arm-v7/rclone > ${RCLONE} || rm ${RCLONE}
       rm -f "${rcloneTemp}"
   fi
 fi

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -79,7 +79,9 @@ while read url || [ -n "$url" ]; do
     remote=$(echo "$url" | cut -d: -f1)
     dir="$Lib/$remote/"
     mkdir -p "$dir"
-    RCLONE_COMMAND="${RCLONE} ${RCLONE_OP} --no-check-certificate --error-on-no-transfer -v --config ${RCloneConfig}"
+    # --modify-window 3s
+    # see https://www.mobileread.com/forums/showpost.php?p=4299209&postcount=11
+    RCLONE_COMMAND="${RCLONE} ${RCLONE_OP} --modify-window 3s --no-check-certificate --error-on-no-transfer -v --config ${RCloneConfig}"
     echo ${RCLONE_COMMAND} \"$url\" \"$dir\"
     ${RCLONE_COMMAND} "$url" "$dir"
     rclone_status=$?

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -15,7 +15,6 @@ fi
 
 RCLONE_OP=""
 if grep -q "^REMOVE_DELETED$" $UserConfig; then
-	echo "$Lib/filesList.log" > "$Lib/filesList.log"
     echo "Will delete files no longer present on remote"
     # Remove deleted, do a sync.
     RCLONE_OP="sync"


### PR DESCRIPTION
I made the following changes:
- Make installation of rclone more robust
I had problems with the installation of `rclone`. Sometimes the download failed (probably because of a weak Wifi), and then it still tried to unzip the partially downloaded file, resulting in a zero-length `rclone` binary. The next time the Kobo retried it it concluded that `rclone` was present.
So I changed the code to do a length check on the binary, and also to remove it when the downloading fails.
Also changed the version to 1.66.

- Don't do a library refresh if no files were transferred, otherwise the Kobo resets to the Home page instead of keeping the current book open.

- move check for REMOVE_DELETED out of the loop, just a bit more efficient
- Some other minor tweaks.

I am very content with the result. But I am working now on making this a menu item with NickelMenu. I think this  way you have a bit more control.